### PR TITLE
Made it compatible with non-MacVim editors

### DIFF
--- a/plugin/typora.vim
+++ b/plugin/typora.vim
@@ -1,4 +1,5 @@
-if has('mac')
+let uname = system('uname -s')
+if stridx(uname,"Darwin") != -1
 
   function! typora#launch()
       " Launch Typora


### PR DESCRIPTION
has('mac') is true only when using MacVim and it's false in terminal vim. This just checks to see what uname returns instead